### PR TITLE
fix(link-to): do not strip single slash. fixes #71

### DIFF
--- a/libs/router/src/lib/link-to.directive.ts
+++ b/libs/router/src/lib/link-to.directive.ts
@@ -80,6 +80,6 @@ export class LinkTo {
 
   private _cleanUpHref(href: string = ''): string {
     // Trim whitespaces and remove trailing slashes
-    return href.trim().replace(/[\/]+$/, '');
+    return href.trim().replace(/(?!^)\/+$/, '');
   }
 }


### PR DESCRIPTION
Improved regex to ignore the leading slash